### PR TITLE
Fix method typo in PatternFinder

### DIFF
--- a/src/main/java/com/github/damiano1996/jetbrains/incoder/tool/window/chat/body/messages/ai/markdown/blocks/PatternFinder.java
+++ b/src/main/java/com/github/damiano1996/jetbrains/incoder/tool/window/chat/body/messages/ai/markdown/blocks/PatternFinder.java
@@ -4,7 +4,7 @@ import java.util.regex.Pattern;
 
 public class PatternFinder {
 
-    public int getFistMatchIndex(String pattern, String match) throws PatternNotFound {
+    public int getFirstMatchIndex(String pattern, String match) throws PatternNotFound {
         var matcher = Pattern.compile(pattern).matcher(match);
 
         if (matcher.find()) {

--- a/src/main/java/com/github/damiano1996/jetbrains/incoder/tool/window/chat/body/messages/ai/markdown/blocks/code/CodeMarkdownBlock.java
+++ b/src/main/java/com/github/damiano1996/jetbrains/incoder/tool/window/chat/body/messages/ai/markdown/blocks/code/CodeMarkdownBlock.java
@@ -97,7 +97,7 @@ public class CodeMarkdownBlock implements MarkdownBlock, Disposable {
 
     private void lookForNextTextBlock(String code) throws PatternFinder.PatternNotFound {
         int delimiterIndex =
-                new PatternFinder().getFistMatchIndex(MARKDOWN_CODE_BLOCK_END_REGEX, code);
+                new PatternFinder().getFirstMatchIndex(MARKDOWN_CODE_BLOCK_END_REGEX, code);
 
         log.debug("Text block found at index: {}", delimiterIndex);
 

--- a/src/main/java/com/github/damiano1996/jetbrains/incoder/tool/window/chat/body/messages/ai/markdown/blocks/text/TextMarkdownBlock.java
+++ b/src/main/java/com/github/damiano1996/jetbrains/incoder/tool/window/chat/body/messages/ai/markdown/blocks/text/TextMarkdownBlock.java
@@ -43,7 +43,7 @@ public class TextMarkdownBlock implements MarkdownBlock {
         String markdown = markdownEditorPane.getText();
 
         int delimiterIndex =
-                new PatternFinder().getFistMatchIndex(MARKDOWN_CODE_BLOCK_START_REGEX, markdown);
+                new PatternFinder().getFirstMatchIndex(MARKDOWN_CODE_BLOCK_START_REGEX, markdown);
         log.debug("Code block found at index: {}", delimiterIndex);
 
         var textUntilCode = markdown.substring(0, delimiterIndex);


### PR DESCRIPTION
## Summary
- rename `getFistMatchIndex` to `getFirstMatchIndex`
- update all usages

## Testing
- `./gradlew check` *(fails: Unable to tunnel through proxy)*
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6847b9de0a788321aee5adef951cad72